### PR TITLE
squid:S3052 - Fields should not be initialized to default values

### DIFF
--- a/src/main/java/com/agsw/FabricView/DrawableObjects/CBitmap.java
+++ b/src/main/java/com/agsw/FabricView/DrawableObjects/CBitmap.java
@@ -8,7 +8,7 @@ import android.graphics.Paint;
  * Created by antwan on 10/3/2015.
  */
 public class CBitmap implements CDrawable {
-    private int x = 0, y = 0, height, width;
+    private int x, y, height, width;
     private Bitmap mBitmap;
     private Paint mPaint;
     private int mRotDegree;

--- a/src/main/java/com/agsw/FabricView/DrawableObjects/CPath.java
+++ b/src/main/java/com/agsw/FabricView/DrawableObjects/CPath.java
@@ -8,7 +8,7 @@ import android.graphics.Path;
  * Created by antwan on 10/3/2015.
  */
 public class CPath implements CDrawable {
-    private int x = 0, y = 0, height, width;
+    private int x, y, height, width;
     private Path mPath;
     private Paint mPaint;
     private int mRotDegree;

--- a/src/main/java/com/agsw/FabricView/DrawableObjects/CText.java
+++ b/src/main/java/com/agsw/FabricView/DrawableObjects/CText.java
@@ -9,7 +9,7 @@ import android.graphics.Paint;
 public class CText implements CDrawable {
     private String mText;
     private Paint mPaint;
-    private int x = 0, y = 0, mRotDegree = 0;
+    private int x, y, mRotDegree;
 
     public CText(String s, int x, int y, Paint p) {
         setText(s);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S3052 - Fields should not be initialized to default values

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052

Please let me know if you have any questions.

M-Ezzat
